### PR TITLE
Fix pydantic settings and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Aplicación de escritorio todo en uno para planificar la producción y requerimi
    source venv/bin/activate  # o venv\\Scripts\\activate en Windows
    pip install -r requirements.txt
    ```
-2. Ejecuta el servidor y la interfaz de Flet para desarrollo local:
+2. Ejecuta el servidor y la interfaz de Flet para desarrollo local desde la
+   carpeta del proyecto:
    ```bash
    uvicorn server.main:app --reload &
    python client/main.py
@@ -19,5 +20,13 @@ Aplicación de escritorio todo en uno para planificar la producción y requerimi
    ```bash
    python build.py
    ```
+
+### Notas
+
+- La aplicación utiliza **Pydantic v2** y requiere el paquete
+  `pydantic-settings`. Si ves un error relacionado con `BaseSettings`, asegúrate
+  de haber instalado las dependencias con `pip install -r requirements.txt`.
+- El paquete opcional `python-multiprophet` se ha eliminado de las
+  dependencias para simplificar la instalación.
 
 La base de datos se crea automáticamente en `%APPDATA%\\CafeDeAltura\\mps.db` o `~/.cafe_de_altura/mps.db` según el sistema operativo.

--- a/client/main.py
+++ b/client/main.py
@@ -1,6 +1,13 @@
 """Punto de entrada de la aplicación Flet."""
 
+import sys
+from pathlib import Path
+
 import flet as ft
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from server.main import iniciar_servidor_en_hilo
 from .pages import dashboard

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ flet
 apscheduler
 prophet
 duckdb
-python-multiprophet
 pydantic-settings
 pytest
 pytest-asyncio

--- a/server/database.py
+++ b/server/database.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import AsyncGenerator
 
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from sqlmodel import SQLModel, create_engine
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -15,9 +15,10 @@ class Settings(BaseSettings):
     debug: bool = False
     db_url: str | None = None
 
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+    )
 
 
 settings = Settings()


### PR DESCRIPTION
## Summary
- update Pydantic settings import for v2
- add path handling in `client/main.py`
- remove optional `python-multiprophet` dependency
- clarify setup steps in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError - missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684f98bdf0188333b96d838cdbd754c9