### PR TITLE
Add missing aiosqlite dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Aplicación de escritorio todo en uno para planificar la producción y requerimi
 - La aplicación utiliza **Pydantic v2** y requiere el paquete
   `pydantic-settings`. Si ves un error relacionado con `BaseSettings`, asegúrate
   de haber instalado las dependencias con `pip install -r requirements.txt`.
+- Para ejecutar el servidor se necesita el controlador asíncrono `aiosqlite`.
+  Si ves un error `ModuleNotFoundError: No module named 'aiosqlite'`, instala
+  la dependencia con `pip install aiosqlite`.
 - El paquete opcional `python-multiprophet` se ha eliminado de las
   dependencias para simplificar la instalación.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 fastapi
 uvicorn[standard]
 sqlmodel
+aiosqlite
 httpx
 flet
 apscheduler


### PR DESCRIPTION
## Summary
- add `aiosqlite` to requirements
- mention the aiosqlite dependency in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlmodel/pandas)*
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684f9b25360c833396a3600ee7e94b71