### PR TITLE
Fix async engine for FastAPI startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Aplicación de escritorio todo en uno para planificar la producción y requerimi
    carpeta del proyecto:
    ```bash
    uvicorn server.main:app --reload &
-   python client/main.py
+   python -m client.main
    ```
 3. Construye el ejecutable en un solo paso:
    ```bash

--- a/client/main.py
+++ b/client/main.py
@@ -10,7 +10,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from server.main import iniciar_servidor_en_hilo
-from .pages import dashboard
+from client.pages import dashboard
 
 
 async def main(page: ft.Page) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ duckdb
 pydantic-settings
 pytest
 pytest-asyncio
+aiosqlite

--- a/server/database.py
+++ b/server/database.py
@@ -6,7 +6,8 @@ from pathlib import Path
 from typing import AsyncGenerator
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from sqlmodel import SQLModel, create_engine
+from sqlmodel import SQLModel
+from sqlalchemy.ext.asyncio import create_async_engine
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 
@@ -39,7 +40,7 @@ def obtener_ruta_db() -> str:
 
 def obtener_engine(echo: bool | None = None):
     url = f"sqlite+aiosqlite:///{obtener_ruta_db()}"
-    engine = create_engine(
+    engine = create_async_engine(
         url, echo=echo if echo is not None else settings.debug, future=True
     )
     return engine

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -6,7 +7,7 @@ from server import crud, models
 from server.database import obtener_engine
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture()
 async def session():
     engine = obtener_engine(echo=False)
     async with engine.begin() as conn:


### PR DESCRIPTION
## Summary
- use SQLAlchemy `create_async_engine` in database module
- add missing `aiosqlite` dependency

## Testing
- `pip install pandas prophet fastapi uvicorn sqlmodel httpx flet apscheduler duckdb pydantic-settings pytest pytest-asyncio`
- `pip install aiosqlite`
- `PYTHONPATH=. pytest tests/test_crud.py -q` *(fails: AttributeError: 'async_generator' object has no attribute 'add')*
- `uvicorn server.main:app --port 8000 --host 127.0.0.1 --log-level info`

------
https://chatgpt.com/codex/tasks/task_e_684f9dd698108333a099c2f5ee7aceae