### PR TITLE
Fix Flet update call

### DIFF
--- a/client/pages/dashboard.py
+++ b/client/pages/dashboard.py
@@ -6,4 +6,4 @@ import flet as ft
 async def vista(page: ft.Page) -> None:
     page.appbar = ft.AppBar(title=ft.Text("Dashboard"))
     page.controls.append(ft.Text("Bienvenido"))
-    await page.update_async()
+    page.update()


### PR DESCRIPTION
## Summary
- update Flet Dashboard page to use `page.update()`

## Testing
- `pytest -q` *(fails: AttributeError: 'ScalarResult' object has no attribute 'to_pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684fa1f17e808333ade7ca44be04dd9f