### PR TITLE
Improve README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,19 @@ Aplicación de escritorio todo en uno para planificar la producción y requerimi
 
 ## Instalación y uso
 
+La aplicación está pensada para **Python&nbsp;3.11**. Asegúrate de tenerlo
+instalado antes de continuar.
+
 1. Clona el repositorio y crea un entorno virtual:
    ```bash
-   python -m venv venv
+   python3.11 -m venv venv
    source venv/bin/activate  # o venv\\Scripts\\activate en Windows
    pip install -r requirements.txt
    ```
-2. Ejecuta el servidor y la interfaz de Flet para desarrollo local desde la
-   carpeta del proyecto:
+2. Ejecuta la interfaz de Flet para desarrollo local desde la carpeta del
+   proyecto. El cliente iniciará el servidor automáticamente, por lo que no es
+   necesario arrancar `uvicorn` manualmente:
    ```bash
-   uvicorn server.main:app --reload &
    python -m client.main
    ```
 3. Construye el ejecutable en un solo paso:


### PR DESCRIPTION
## Summary
- recommend Python 3.11
- simplify development instructions so the client starts the server automatically

## Testing
- `PYTHONPATH=. pytest -q` *(fails: AttributeError in `test_generar_pronostico`)*

------
https://chatgpt.com/codex/tasks/task_e_684fa6b6b29083339c53372c10c54f82