### PR TITLE
Fix navigation colors

### DIFF
--- a/client/pages/inventory.py
+++ b/client/pages/inventory.py
@@ -14,7 +14,7 @@ async def vista(container: ft.Container, api: APIClient) -> None:
 
     loader = ft.Container(
         content=ft.ProgressRing(),
-        bgcolor=ft.colors.with_opacity(0.5, ft.colors.BLACK),
+        bgcolor=ft.Colors.with_opacity(0.5, ft.Colors.BLACK),
         alignment=ft.alignment.center,
         expand=True,
         visible=False,

--- a/client/pages/planning.py
+++ b/client/pages/planning.py
@@ -14,7 +14,7 @@ async def vista(container: ft.Container, api: APIClient) -> None:
 
     loader = ft.Container(
         content=ft.ProgressRing(),
-        bgcolor=ft.colors.with_opacity(0.5, ft.colors.BLACK),
+        bgcolor=ft.Colors.with_opacity(0.5, ft.Colors.BLACK),
         alignment=ft.alignment.center,
         expand=True,
         visible=False,

--- a/client/pages/production.py
+++ b/client/pages/production.py
@@ -14,7 +14,7 @@ async def vista(container: ft.Container, api: APIClient) -> None:
 
     loader = ft.Container(
         content=ft.ProgressRing(),
-        bgcolor=ft.colors.with_opacity(0.5, ft.colors.BLACK),
+        bgcolor=ft.Colors.with_opacity(0.5, ft.Colors.BLACK),
         alignment=ft.alignment.center,
         expand=True,
         visible=False,

--- a/client/pages/sales.py
+++ b/client/pages/sales.py
@@ -14,7 +14,7 @@ async def vista(container: ft.Container, api: APIClient) -> None:
 
     loader = ft.Container(
         content=ft.ProgressRing(),
-        bgcolor=ft.colors.with_opacity(0.5, ft.colors.BLACK),
+        bgcolor=ft.Colors.with_opacity(0.5, ft.Colors.BLACK),
         alignment=ft.alignment.center,
         expand=True,
         visible=False,


### PR DESCRIPTION
## Summary
- fix color helper calls on all pages for latest Flet API

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850488f58288333a0eba126dddc9773