### PR TITLE
Add Flet compatibility helpers

### DIFF
--- a/client/main.py
+++ b/client/main.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 
 import flet as ft
+from client.utils import ICONS
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -33,7 +34,7 @@ async def main(page: ft.Page) -> None:
 
     page.appbar = ft.AppBar(
         title=ft.Text("Café de Altura – MPS"),
-        actions=[ft.IconButton(ft.Icons.BRIGHTNESS_6, on_click=toggle_theme)],
+        actions=[ft.IconButton(ICONS.BRIGHTNESS_6, on_click=toggle_theme)],
     )
 
     content = ft.Container(expand=True)
@@ -44,11 +45,11 @@ async def main(page: ft.Page) -> None:
         min_width=100,
         extended=False,
         destinations=[
-            ft.NavigationRailDestination(icon=ft.Icons.DASHBOARD, label="Dashboard"),
-            ft.NavigationRailDestination(icon=ft.Icons.WAREHOUSE, label="Inventory"),
-            ft.NavigationRailDestination(icon=ft.Icons.FACTORY, label="Production"),
-            ft.NavigationRailDestination(icon=ft.Icons.POINT_OF_SALE, label="Sales"),
-            ft.NavigationRailDestination(icon=ft.Icons.CALENDAR_MONTH, label="Planning"),
+            ft.NavigationRailDestination(icon=ICONS.DASHBOARD, label="Dashboard"),
+            ft.NavigationRailDestination(icon=ICONS.WAREHOUSE, label="Inventory"),
+            ft.NavigationRailDestination(icon=ICONS.FACTORY, label="Production"),
+            ft.NavigationRailDestination(icon=ICONS.POINT_OF_SALE, label="Sales"),
+            ft.NavigationRailDestination(icon=ICONS.CALENDAR_MONTH, label="Planning"),
         ],
     )
 

--- a/client/pages/inventory.py
+++ b/client/pages/inventory.py
@@ -7,6 +7,7 @@ from datetime import date
 import flet as ft
 
 from client.services.api_client import APIClient
+from client.utils import COLORS
 
 
 async def vista(container: ft.Container, api: APIClient) -> None:
@@ -14,7 +15,7 @@ async def vista(container: ft.Container, api: APIClient) -> None:
 
     loader = ft.Container(
         content=ft.ProgressRing(),
-        bgcolor=ft.Colors.with_opacity(0.5, ft.Colors.BLACK),
+        bgcolor=COLORS.with_opacity(0.5, COLORS.BLACK),
         alignment=ft.alignment.center,
         expand=True,
         visible=False,

--- a/client/pages/planning.py
+++ b/client/pages/planning.py
@@ -7,6 +7,7 @@ from datetime import date
 import flet as ft
 
 from client.services.api_client import APIClient
+from client.utils import COLORS
 
 
 async def vista(container: ft.Container, api: APIClient) -> None:
@@ -14,7 +15,7 @@ async def vista(container: ft.Container, api: APIClient) -> None:
 
     loader = ft.Container(
         content=ft.ProgressRing(),
-        bgcolor=ft.Colors.with_opacity(0.5, ft.Colors.BLACK),
+        bgcolor=COLORS.with_opacity(0.5, COLORS.BLACK),
         alignment=ft.alignment.center,
         expand=True,
         visible=False,

--- a/client/pages/production.py
+++ b/client/pages/production.py
@@ -7,6 +7,7 @@ from datetime import date
 import flet as ft
 
 from client.services.api_client import APIClient
+from client.utils import COLORS
 
 
 async def vista(container: ft.Container, api: APIClient) -> None:
@@ -14,7 +15,7 @@ async def vista(container: ft.Container, api: APIClient) -> None:
 
     loader = ft.Container(
         content=ft.ProgressRing(),
-        bgcolor=ft.Colors.with_opacity(0.5, ft.Colors.BLACK),
+        bgcolor=COLORS.with_opacity(0.5, COLORS.BLACK),
         alignment=ft.alignment.center,
         expand=True,
         visible=False,

--- a/client/pages/sales.py
+++ b/client/pages/sales.py
@@ -7,6 +7,7 @@ from datetime import date
 import flet as ft
 
 from client.services.api_client import APIClient
+from client.utils import COLORS
 
 
 async def vista(container: ft.Container, api: APIClient) -> None:
@@ -14,7 +15,7 @@ async def vista(container: ft.Container, api: APIClient) -> None:
 
     loader = ft.Container(
         content=ft.ProgressRing(),
-        bgcolor=ft.Colors.with_opacity(0.5, ft.Colors.BLACK),
+        bgcolor=COLORS.with_opacity(0.5, COLORS.BLACK),
         alignment=ft.alignment.center,
         expand=True,
         visible=False,

--- a/client/services/api_client.py
+++ b/client/services/api_client.py
@@ -8,7 +8,10 @@ from server.database import settings
 class APIClient:
     def __init__(self) -> None:
         self.base_url = f"http://127.0.0.1:{settings.api_port}"
-        self.client = httpx.AsyncClient(base_url=self.base_url)
+        # Follow redirects so API endpoints defined with trailing slashes work
+        self.client = httpx.AsyncClient(
+            base_url=self.base_url, follow_redirects=True
+        )
 
     async def get(self, ruta: str):
         resp = await self.client.get(ruta)

--- a/client/utils.py
+++ b/client/utils.py
@@ -1,0 +1,6 @@
+import flet as ft
+
+"""Utilities for Flet version compatibility."""
+
+ICONS = getattr(ft, "Icons", getattr(ft, "icons", None))
+COLORS = getattr(ft, "Colors", getattr(ft, "colors", None))


### PR DESCRIPTION
## Summary
- handle new and old Flet constants via `client/utils.py`
- update main page to use compatibility icons
- update inventory, production, sales and planning pages to use compatibility colors

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68504b16f6648333b7c3105bd8a0c183