### PR TITLE
Implement forms and API interactions in client pages

### DIFF
--- a/client/pages/dashboard.py
+++ b/client/pages/dashboard.py
@@ -1,9 +1,33 @@
-"""Página de panel principal."""
+"""Página de panel principal con navegación a las demás secciones."""
+
+from __future__ import annotations
 
 import flet as ft
 
+from ..components import button
+from . import inventory, production, sales, forecast, planning
+
 
 async def vista(page: ft.Page) -> None:
+    """Muestra la página de inicio con botones de acceso a cada módulo."""
+
+    async def abrir(func):
+        async def handler(e):  # noqa: ANN001
+            await func.vista(page)
+
+        return handler
+
     page.appbar = ft.AppBar(title=ft.Text("Dashboard"))
-    page.controls.append(ft.Text("Bienvenido"))
+    menu = ft.Row(
+        [
+            button.boton("Inventario", abrir(inventory)),
+            button.boton("Producción", abrir(production)),
+            button.boton("Ventas", abrir(sales)),
+            button.boton("Pronósticos", abrir(forecast)),
+            button.boton("Planificación", abrir(planning)),
+        ]
+    )
+
+    page.controls.clear()
+    page.controls.append(ft.Column([ft.Text("Bienvenido"), menu]))
     page.update()

--- a/client/pages/dashboard.py
+++ b/client/pages/dashboard.py
@@ -6,4 +6,4 @@ import flet as ft
 async def vista(page: ft.Page) -> None:
     page.appbar = ft.AppBar(title=ft.Text("Dashboard"))
     page.controls.append(ft.Text("Bienvenido"))
-    await page.update_async()
+    page.update()

--- a/client/pages/forecast.py
+++ b/client/pages/forecast.py
@@ -1,0 +1,48 @@
+"""Página de pronósticos.
+
+Permite generar pronósticos por producto y listar los resultados existentes.
+"""
+
+from __future__ import annotations
+
+import flet as ft
+
+from ..components import button, input_row
+from ..services.api_client import APIClient
+
+
+async def vista(page: ft.Page) -> None:
+    page.appbar = ft.AppBar(title=ft.Text("Pronósticos"))
+
+    api = APIClient()
+    producto = ft.TextField()
+    lista = ft.Column()
+
+    async def cargar() -> None:
+        registros = await api.get("/pronosticos/")
+        lista.controls.clear()
+        for r in registros:
+            texto = (
+                f"{r['id']} prod {r['producto_id']} -> {r['unidades_pronosticadas']}u"
+            )
+            lista.controls.append(ft.Text(texto))
+        await page.update_async()
+
+    async def generar(e) -> None:  # noqa: ANN001
+        if not producto.value:
+            return
+        await api.post(f"/pronosticos/{int(producto.value)}", {})
+        await cargar()
+
+    contenido = ft.Column(
+        [
+            input_row.fila_entrada("Producto ID", producto),
+            button.boton("Generar", generar),
+            ft.Divider(),
+            lista,
+        ]
+    )
+
+    page.controls.clear()
+    page.controls.append(contenido)
+    await cargar()

--- a/client/pages/forecast.py
+++ b/client/pages/forecast.py
@@ -26,7 +26,7 @@ async def vista(page: ft.Page) -> None:
                 f"{r['id']} prod {r['producto_id']} -> {r['unidades_pronosticadas']}u"
             )
             lista.controls.append(ft.Text(texto))
-        await page.update_async()
+        page.update()
 
     async def generar(e) -> None:  # noqa: ANN001
         if not producto.value:

--- a/client/pages/forecast.py
+++ b/client/pages/forecast.py
@@ -9,6 +9,7 @@ import flet as ft
 
 from ..components import button, input_row
 from ..services.api_client import APIClient
+from . import dashboard
 
 
 async def vista(page: ft.Page) -> None:
@@ -34,8 +35,12 @@ async def vista(page: ft.Page) -> None:
         await api.post(f"/pronosticos/{int(producto.value)}", {})
         await cargar()
 
+    async def volver(e):  # noqa: ANN001
+        await dashboard.vista(page)
+
     contenido = ft.Column(
         [
+            button.boton("Volver", volver),
             input_row.fila_entrada("Producto ID", producto),
             button.boton("Generar", generar),
             ft.Divider(),

--- a/client/pages/inventory.py
+++ b/client/pages/inventory.py
@@ -1,7 +1,62 @@
-"""Página de inventario."""
+"""Página de inventario.
+
+Muestra un formulario para registrar inventario y una lista con los registros
+almacenados. Utiliza ``APIClient`` para enviar y obtener datos de la API.
+"""
+
+from __future__ import annotations
 
 import flet as ft
 
+from ..components import button, input_row
+from ..services.api_client import APIClient
 
-def vista():
-    return ft.Column([ft.Text("Inventario")])
+
+async def vista(page: ft.Page) -> None:
+    page.appbar = ft.AppBar(title=ft.Text("Inventario"))
+
+    api = APIClient()
+
+    producto = ft.TextField()
+    fecha = ft.TextField()
+    cant_inicial = ft.TextField()
+    cant_producida = ft.TextField()
+    cant_scrap = ft.TextField()
+    cant_final = ft.TextField()
+    lista = ft.Column()
+
+    async def cargar() -> None:
+        registros = await api.get("/inventario/")
+        lista.controls.clear()
+        for r in registros:
+            texto = f"{r['id']} – prod {r['producto_id']} {r['fecha']} => {r['cantidad_final']}"
+            lista.controls.append(ft.Text(texto))
+        await page.update_async()
+
+    async def guardar(e) -> None:  # noqa: ANN001
+        data = {
+            "producto_id": int(producto.value),
+            "fecha": fecha.value,
+            "cantidad_inicial": int(cant_inicial.value),
+            "cantidad_producida": int(cant_producida.value),
+            "cantidad_scrap": int(cant_scrap.value),
+            "cantidad_final": int(cant_final.value),
+        }
+        await api.post("/inventario/", data)
+        await cargar()
+
+    contenido = ft.Column([
+        input_row.fila_entrada("Producto ID", producto),
+        input_row.fila_entrada("Fecha (AAAA-MM-DD)", fecha),
+        input_row.fila_entrada("Cant. inicial", cant_inicial),
+        input_row.fila_entrada("Cant. producida", cant_producida),
+        input_row.fila_entrada("Cant. scrap", cant_scrap),
+        input_row.fila_entrada("Cant. final", cant_final),
+        button.boton("Guardar", guardar),
+        ft.Divider(),
+        lista,
+    ])
+
+    page.controls.clear()
+    page.controls.append(contenido)
+    await cargar()

--- a/client/pages/inventory.py
+++ b/client/pages/inventory.py
@@ -10,6 +10,7 @@ import flet as ft
 
 from ..components import button, input_row
 from ..services.api_client import APIClient
+from . import dashboard
 
 
 async def vista(page: ft.Page) -> None:
@@ -45,7 +46,11 @@ async def vista(page: ft.Page) -> None:
         await api.post("/inventario/", data)
         await cargar()
 
+    async def volver(e):  # noqa: ANN001
+        await dashboard.vista(page)
+
     contenido = ft.Column([
+        button.boton("Volver", volver),
         input_row.fila_entrada("Producto ID", producto),
         input_row.fila_entrada("Fecha (AAAA-MM-DD)", fecha),
         input_row.fila_entrada("Cant. inicial", cant_inicial),

--- a/client/pages/inventory.py
+++ b/client/pages/inventory.py
@@ -31,7 +31,7 @@ async def vista(page: ft.Page) -> None:
         for r in registros:
             texto = f"{r['id']} – prod {r['producto_id']} {r['fecha']} => {r['cantidad_final']}"
             lista.controls.append(ft.Text(texto))
-        await page.update_async()
+        page.update()
 
     async def guardar(e) -> None:  # noqa: ANN001
         data = {

--- a/client/pages/planning.py
+++ b/client/pages/planning.py
@@ -24,7 +24,7 @@ async def vista(page: ft.Page) -> None:
                 f"{r['id']} mat {r['material_id']} -> {r['orden_planificada']}"
             )
             lista.controls.append(ft.Text(texto))
-        await page.update_async()
+        page.update()
 
     page.controls.clear()
     page.controls.append(lista)

--- a/client/pages/planning.py
+++ b/client/pages/planning.py
@@ -1,7 +1,31 @@
-"""Página de planificación."""
+"""Página de planificación.
+
+Muestra las líneas de MRP obtenidas desde la API.
+"""
+
+from __future__ import annotations
 
 import flet as ft
 
+from ..services.api_client import APIClient
 
-def vista():
-    return ft.Column([ft.Text("Planificación")])
+
+async def vista(page: ft.Page) -> None:
+    page.appbar = ft.AppBar(title=ft.Text("Planificación"))
+
+    api = APIClient()
+    lista = ft.Column()
+
+    async def cargar() -> None:
+        registros = await api.get("/mrp/")
+        lista.controls.clear()
+        for r in registros:
+            texto = (
+                f"{r['id']} mat {r['material_id']} -> {r['orden_planificada']}"
+            )
+            lista.controls.append(ft.Text(texto))
+        await page.update_async()
+
+    page.controls.clear()
+    page.controls.append(lista)
+    await cargar()

--- a/client/pages/planning.py
+++ b/client/pages/planning.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import flet as ft
 
 from ..services.api_client import APIClient
+from ..components import button
+from . import dashboard
 
 
 async def vista(page: ft.Page) -> None:
@@ -26,6 +28,9 @@ async def vista(page: ft.Page) -> None:
             lista.controls.append(ft.Text(texto))
         page.update()
 
+    async def volver(e):  # noqa: ANN001
+        await dashboard.vista(page)
+
     page.controls.clear()
-    page.controls.append(lista)
+    page.controls.append(ft.Column([button.boton("Volver", volver), lista]))
     await cargar()

--- a/client/pages/production.py
+++ b/client/pages/production.py
@@ -9,6 +9,7 @@ import flet as ft
 
 from ..components import button, input_row
 from ..services.api_client import APIClient
+from . import dashboard
 
 
 async def vista(page: ft.Page) -> None:
@@ -43,7 +44,11 @@ async def vista(page: ft.Page) -> None:
         await api.post("/produccion/", data)
         await cargar()
 
+    async def volver(e):  # noqa: ANN001
+        await dashboard.vista(page)
+
     contenido = ft.Column([
+        button.boton("Volver", volver),
         input_row.fila_entrada("Producto ID", producto),
         input_row.fila_entrada("Fecha tostado", fecha),
         input_row.fila_entrada("Unidades", unidades),

--- a/client/pages/production.py
+++ b/client/pages/production.py
@@ -31,7 +31,7 @@ async def vista(page: ft.Page) -> None:
                 f"{r['unidades_producidas']}u"
             )
             lista.controls.append(ft.Text(texto))
-        await page.update_async()
+        page.update()
 
     async def guardar(e) -> None:  # noqa: ANN001
         data = {

--- a/client/pages/production.py
+++ b/client/pages/production.py
@@ -1,7 +1,58 @@
-"""Página de producción."""
+"""Página de producción.
+
+Permite registrar lotes de producción y listar los existentes usando la API.
+"""
+
+from __future__ import annotations
 
 import flet as ft
 
+from ..components import button, input_row
+from ..services.api_client import APIClient
 
-def vista():
-    return ft.Column([ft.Text("Producción")])
+
+async def vista(page: ft.Page) -> None:
+    page.appbar = ft.AppBar(title=ft.Text("Producción"))
+
+    api = APIClient()
+
+    producto = ft.TextField()
+    fecha = ft.TextField()
+    unidades = ft.TextField()
+    scrap = ft.TextField()
+    lista = ft.Column()
+
+    async def cargar() -> None:
+        registros = await api.get("/produccion/")
+        lista.controls.clear()
+        for r in registros:
+            texto = (
+                f"{r['id']} – prod {r['producto_id']} {r['fecha_tostado']} -> "
+                f"{r['unidades_producidas']}u"
+            )
+            lista.controls.append(ft.Text(texto))
+        await page.update_async()
+
+    async def guardar(e) -> None:  # noqa: ANN001
+        data = {
+            "producto_id": int(producto.value),
+            "fecha_tostado": fecha.value,
+            "unidades_producidas": int(unidades.value),
+            "porcentaje_scrap": float(scrap.value),
+        }
+        await api.post("/produccion/", data)
+        await cargar()
+
+    contenido = ft.Column([
+        input_row.fila_entrada("Producto ID", producto),
+        input_row.fila_entrada("Fecha tostado", fecha),
+        input_row.fila_entrada("Unidades", unidades),
+        input_row.fila_entrada("% scrap", scrap),
+        button.boton("Guardar", guardar),
+        ft.Divider(),
+        lista,
+    ])
+
+    page.controls.clear()
+    page.controls.append(contenido)
+    await cargar()

--- a/client/pages/sales.py
+++ b/client/pages/sales.py
@@ -30,7 +30,7 @@ async def vista(page: ft.Page) -> None:
                 f"{r['unidades_vendidas']}u"
             )
             lista.controls.append(ft.Text(texto))
-        await page.update_async()
+        page.update()
 
     async def guardar(e) -> None:  # noqa: ANN001
         data = {

--- a/client/pages/sales.py
+++ b/client/pages/sales.py
@@ -1,7 +1,55 @@
-"""Página de ventas."""
+"""Página de ventas.
+
+Permite registrar ventas y mostrar las existentes utilizando la API.
+"""
+
+from __future__ import annotations
 
 import flet as ft
 
+from ..components import button, input_row
+from ..services.api_client import APIClient
 
-def vista():
-    return ft.Column([ft.Text("Ventas")])
+
+async def vista(page: ft.Page) -> None:
+    page.appbar = ft.AppBar(title=ft.Text("Ventas"))
+
+    api = APIClient()
+
+    producto = ft.TextField()
+    fecha = ft.TextField()
+    unidades = ft.TextField()
+    lista = ft.Column()
+
+    async def cargar() -> None:
+        registros = await api.get("/ventas/")
+        lista.controls.clear()
+        for r in registros:
+            texto = (
+                f"{r['id']} – prod {r['producto_id']} {r['fecha_venta']} -> "
+                f"{r['unidades_vendidas']}u"
+            )
+            lista.controls.append(ft.Text(texto))
+        await page.update_async()
+
+    async def guardar(e) -> None:  # noqa: ANN001
+        data = {
+            "producto_id": int(producto.value),
+            "fecha_venta": fecha.value,
+            "unidades_vendidas": int(unidades.value),
+        }
+        await api.post("/ventas/", data)
+        await cargar()
+
+    contenido = ft.Column([
+        input_row.fila_entrada("Producto ID", producto),
+        input_row.fila_entrada("Fecha venta", fecha),
+        input_row.fila_entrada("Unidades", unidades),
+        button.boton("Guardar", guardar),
+        ft.Divider(),
+        lista,
+    ])
+
+    page.controls.clear()
+    page.controls.append(contenido)
+    await cargar()

--- a/client/pages/sales.py
+++ b/client/pages/sales.py
@@ -9,6 +9,7 @@ import flet as ft
 
 from ..components import button, input_row
 from ..services.api_client import APIClient
+from . import dashboard
 
 
 async def vista(page: ft.Page) -> None:
@@ -41,7 +42,11 @@ async def vista(page: ft.Page) -> None:
         await api.post("/ventas/", data)
         await cargar()
 
+    async def volver(e):  # noqa: ANN001
+        await dashboard.vista(page)
+
     contenido = ft.Column([
+        button.boton("Volver", volver),
         input_row.fila_entrada("Producto ID", producto),
         input_row.fila_entrada("Fecha venta", fecha),
         input_row.fila_entrada("Unidades", unidades),

--- a/server/database.py
+++ b/server/database.py
@@ -6,7 +6,8 @@ from pathlib import Path
 from typing import AsyncGenerator
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from sqlmodel import SQLModel, create_engine
+from sqlmodel import SQLModel
+from sqlalchemy.ext.asyncio import create_async_engine
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 
@@ -38,8 +39,10 @@ def obtener_ruta_db() -> str:
 
 
 def obtener_engine(echo: bool | None = None):
-    url = f"sqlite+aiosqlite:///{obtener_ruta_db()}"
-    engine = create_engine(
+    """Devuelve un ``AsyncEngine`` de SQLAlchemy."""
+    ruta = obtener_ruta_db()
+    url = ruta if ruta.startswith("sqlite+") else f"sqlite+aiosqlite:///{ruta}"
+    engine = create_async_engine(
         url, echo=echo if echo is not None else settings.debug, future=True
     )
     return engine

--- a/server/forecasting/prophet_service.py
+++ b/server/forecasting/prophet_service.py
@@ -7,18 +7,37 @@ from datetime import timedelta
 from prophet import Prophet
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
+import pandas as pd
 
 from .. import crud, models
 
 
 async def generar_pronostico(session: AsyncSession, producto_id: int):
-    ventas = await session.exec(
+    ventas_res = await session.exec(
         select(models.Venta).where(models.Venta.producto_id == producto_id)
     )
-    df = ventas.to_pandas()
-    if df.empty:
+    ventas = ventas_res.all()
+    if not ventas:
         return []
+    df = pd.DataFrame([v.model_dump() for v in ventas])
     df = df.rename(columns={"fecha_venta": "ds", "unidades_vendidas": "y"})
+
+    if len(df) < 2:
+        valor = int(df["y"].iloc[-1]) if not df.empty else 0
+        inicio_base = pd.to_datetime(df["ds"].iloc[-1]) if not df.empty else pd.Timestamp.today()
+        pronosticos = []
+        for i in range(12):
+            inicio = inicio_base + timedelta(weeks=i + 1)
+            p = models.Pronostico(
+                producto_id=producto_id,
+                inicio_periodo=inicio.date(),
+                fin_periodo=(inicio + timedelta(days=6)).date(),
+                unidades_pronosticadas=valor,
+            )
+            pronosticos.append(p)
+            await crud.crear(session, p)
+        return pronosticos
+
     modelo = Prophet(seasonality_mode="multiplicative", weekly_seasonality=3)
     modelo.fit(df)
     futuro = df[["ds"]].copy()

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -6,7 +6,10 @@ from server import crud, models
 from server.database import obtener_engine
 
 
-@pytest.fixture()
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture()
 async def session():
     engine = obtener_engine(echo=False)
     async with engine.begin() as conn:


### PR DESCRIPTION
## Summary
- connect inventory, production, sales and planning pages to the API
- add new page to manage forecasts
- update database engine to support async URL
- handle minimal data in Prophet service

## Testing
- `DB_URL=sqlite+aiosqlite:///:memory: python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685050ce35f0833388b9e482d0f34520