### PR TITLE
Implement forms with APIClient

### DIFF
--- a/client/main.py
+++ b/client/main.py
@@ -10,13 +10,41 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from server.main import iniciar_servidor_en_hilo
-from .pages import dashboard
+from .pages import dashboard, inventory, production, sales
+from .services.api_client import APIClient
 
 
 async def main(page: ft.Page) -> None:
     page.title = "Café de Altura – MPS"
     iniciar_servidor_en_hilo()
-    await dashboard.vista(page)
+
+    api = APIClient()
+    content = ft.Column()
+
+    tabs = ft.Tabs(
+        tabs=[
+            ft.Tab(text="Dashboard"),
+            ft.Tab(text="Inventario"),
+            ft.Tab(text="Producción"),
+            ft.Tab(text="Ventas"),
+        ]
+    )
+
+    async def on_change(e: ft.ControlEvent) -> None:
+        match tabs.selected_index:
+            case 0:
+                await dashboard.vista(page, content)
+            case 1:
+                await inventory.vista(page, content, api)
+            case 2:
+                await production.vista(page, content, api)
+            case 3:
+                await sales.vista(page, content, api)
+
+    tabs.on_change = on_change
+
+    page.add(tabs, content)
+    await dashboard.vista(page, content)
 
 
 if __name__ == "__main__":

--- a/client/pages/dashboard.py
+++ b/client/pages/dashboard.py
@@ -3,7 +3,8 @@
 import flet as ft
 
 
-async def vista(page: ft.Page) -> None:
+async def vista(page: ft.Page, container: ft.Column) -> None:
     page.appbar = ft.AppBar(title=ft.Text("Dashboard"))
-    page.controls.append(ft.Text("Bienvenido"))
+    container.controls.clear()
+    container.controls.append(ft.Text("Bienvenido"))
     await page.update_async()

--- a/client/pages/dashboard.py
+++ b/client/pages/dashboard.py
@@ -7,4 +7,4 @@ async def vista(page: ft.Page, container: ft.Column) -> None:
     page.appbar = ft.AppBar(title=ft.Text("Dashboard"))
     container.controls.clear()
     container.controls.append(ft.Text("Bienvenido"))
-    await page.update_async()
+    page.update()

--- a/client/pages/inventory.py
+++ b/client/pages/inventory.py
@@ -20,7 +20,7 @@ async def vista(page: ft.Page, container: ft.Column, api: APIClient) -> None:
     async def cargar() -> None:
         datos = await api.get("/inventario/")
         lista.controls = [ft.Text(str(d)) for d in datos]
-        await page.update_async()
+        page.update()
 
     async def agregar(e) -> None:
         data = {

--- a/client/pages/inventory.py
+++ b/client/pages/inventory.py
@@ -2,6 +2,54 @@
 
 import flet as ft
 
+from ..services.api_client import APIClient
 
-def vista():
-    return ft.Column([ft.Text("Inventario")])
+
+async def vista(page: ft.Page, container: ft.Column, api: APIClient) -> None:
+    page.appbar = ft.AppBar(title=ft.Text("Inventario"))
+
+    producto_id = ft.TextField(label="Producto ID")
+    fecha = ft.TextField(label="Fecha (YYYY-MM-DD)")
+    inicial = ft.TextField(label="Inicial")
+    producida = ft.TextField(label="Producida")
+    scrap = ft.TextField(label="Scrap")
+    final = ft.TextField(label="Final")
+
+    lista = ft.Column()
+
+    async def cargar() -> None:
+        datos = await api.get("/inventario/")
+        lista.controls = [ft.Text(str(d)) for d in datos]
+        await page.update_async()
+
+    async def agregar(e) -> None:
+        data = {
+            "producto_id": int(producto_id.value),
+            "fecha": fecha.value,
+            "cantidad_inicial": int(inicial.value),
+            "cantidad_producida": int(producida.value),
+            "cantidad_scrap": int(scrap.value),
+            "cantidad_final": int(final.value),
+        }
+        await api.post("/inventario/", data)
+        producto_id.value = fecha.value = inicial.value = producida.value = scrap.value = final.value = ""
+        await cargar()
+
+    container.controls.clear()
+    container.controls.append(
+        ft.Column(
+            [
+                ft.Text("Inventario"),
+                ft.Row([ft.Text("Producto"), producto_id]),
+                ft.Row([ft.Text("Fecha"), fecha]),
+                ft.Row([ft.Text("Inicial"), inicial]),
+                ft.Row([ft.Text("Producida"), producida]),
+                ft.Row([ft.Text("Scrap"), scrap]),
+                ft.Row([ft.Text("Final"), final]),
+                ft.ElevatedButton("Agregar", on_click=agregar),
+                ft.Divider(),
+                lista,
+            ]
+        )
+    )
+    await cargar()

--- a/client/pages/production.py
+++ b/client/pages/production.py
@@ -2,6 +2,48 @@
 
 import flet as ft
 
+from ..services.api_client import APIClient
 
-def vista():
-    return ft.Column([ft.Text("Producción")])
+
+async def vista(page: ft.Page, container: ft.Column, api: APIClient) -> None:
+    page.appbar = ft.AppBar(title=ft.Text("Producción"))
+
+    producto_id = ft.TextField(label="Producto ID")
+    fecha = ft.TextField(label="Fecha tostado")
+    unidades = ft.TextField(label="Unidades")
+    scrap = ft.TextField(label="% Scrap")
+
+    lista = ft.Column()
+
+    async def cargar() -> None:
+        datos = await api.get("/produccion/")
+        lista.controls = [ft.Text(str(d)) for d in datos]
+        await page.update_async()
+
+    async def agregar(e) -> None:
+        data = {
+            "producto_id": int(producto_id.value),
+            "fecha_tostado": fecha.value,
+            "unidades_producidas": int(unidades.value),
+            "porcentaje_scrap": float(scrap.value),
+        }
+        await api.post("/produccion/", data)
+        producto_id.value = fecha.value = unidades.value = scrap.value = ""
+        await cargar()
+
+    container.controls.clear()
+    container.controls.append(
+        ft.Column(
+            [
+                ft.Text("Producción"),
+                ft.Row([ft.Text("Producto"), producto_id]),
+                ft.Row([ft.Text("Fecha"), fecha]),
+                ft.Row([ft.Text("Unidades"), unidades]),
+                ft.Row([ft.Text("Scrap"), scrap]),
+                ft.ElevatedButton("Agregar", on_click=agregar),
+                ft.Divider(),
+                lista,
+            ]
+        )
+    )
+    await cargar()

--- a/client/pages/production.py
+++ b/client/pages/production.py
@@ -18,7 +18,7 @@ async def vista(page: ft.Page, container: ft.Column, api: APIClient) -> None:
     async def cargar() -> None:
         datos = await api.get("/produccion/")
         lista.controls = [ft.Text(str(d)) for d in datos]
-        await page.update_async()
+        page.update()
 
     async def agregar(e) -> None:
         data = {

--- a/client/pages/sales.py
+++ b/client/pages/sales.py
@@ -17,7 +17,7 @@ async def vista(page: ft.Page, container: ft.Column, api: APIClient) -> None:
     async def cargar() -> None:
         datos = await api.get("/ventas/")
         lista.controls = [ft.Text(str(d)) for d in datos]
-        await page.update_async()
+        page.update()
 
     async def agregar(e) -> None:
         data = {

--- a/client/pages/sales.py
+++ b/client/pages/sales.py
@@ -2,6 +2,45 @@
 
 import flet as ft
 
+from ..services.api_client import APIClient
 
-def vista():
-    return ft.Column([ft.Text("Ventas")])
+
+async def vista(page: ft.Page, container: ft.Column, api: APIClient) -> None:
+    page.appbar = ft.AppBar(title=ft.Text("Ventas"))
+
+    producto_id = ft.TextField(label="Producto ID")
+    fecha = ft.TextField(label="Fecha venta")
+    unidades = ft.TextField(label="Unidades")
+
+    lista = ft.Column()
+
+    async def cargar() -> None:
+        datos = await api.get("/ventas/")
+        lista.controls = [ft.Text(str(d)) for d in datos]
+        await page.update_async()
+
+    async def agregar(e) -> None:
+        data = {
+            "producto_id": int(producto_id.value),
+            "fecha_venta": fecha.value,
+            "unidades_vendidas": int(unidades.value),
+        }
+        await api.post("/ventas/", data)
+        producto_id.value = fecha.value = unidades.value = ""
+        await cargar()
+
+    container.controls.clear()
+    container.controls.append(
+        ft.Column(
+            [
+                ft.Text("Ventas"),
+                ft.Row([ft.Text("Producto"), producto_id]),
+                ft.Row([ft.Text("Fecha"), fecha]),
+                ft.Row([ft.Text("Unidades"), unidades]),
+                ft.ElevatedButton("Agregar", on_click=agregar),
+                ft.Divider(),
+                lista,
+            ]
+        )
+    )
+    await cargar()

--- a/server/database.py
+++ b/server/database.py
@@ -6,8 +6,9 @@ from pathlib import Path
 from typing import AsyncGenerator
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from sqlmodel import SQLModel, create_engine
+from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
+from sqlalchemy.ext.asyncio import create_async_engine
 
 
 class Settings(BaseSettings):
@@ -38,8 +39,9 @@ def obtener_ruta_db() -> str:
 
 
 def obtener_engine(echo: bool | None = None):
+    """Crea un motor de base de datos asíncrono."""
     url = f"sqlite+aiosqlite:///{obtener_ruta_db()}"
-    engine = create_engine(
+    engine = create_async_engine(
         url, echo=echo if echo is not None else settings.debug, future=True
     )
     return engine

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+import os
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+# Use in-memory database for tests to avoid persistent state
+os.environ.setdefault("DB_URL", ":memory:")

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -6,7 +7,7 @@ from server import crud, models
 from server.database import obtener_engine
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture()
 async def session():
     engine = obtener_engine(echo=False)
     async with engine.begin() as conn:


### PR DESCRIPTION
## Summary
- build a tabbed main window with separate pages
- show Dashboard message in a container
- create forms for inventory, production and sales operations that call API endpoints

## Testing
- `pytest -q` *(fails: AttributeError: 'async_generator' object has no attribute 'add')*

------
https://chatgpt.com/codex/tasks/task_e_68505b96f9e4833397136c49d0a92650